### PR TITLE
Consider LDFLAGS while linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 all:$(PROG)
 
 unimap:main.o libunimap.a
-		$(CC) $(CFLAGS) main.o -o $@ -L. -lunimap $(LIBS)
+		$(CC) $(CFLAGS) main.o -o $@ $(LDFLAGS) -L. -lunimap $(LIBS)
 
 libunimap.a:$(OBJS)
 		$(AR) -csru $@ $(OBJS)


### PR DESCRIPTION
Adds `LDFLAGS` to the linking step.

A couple of further suggestions/questions:
1. With the current change the link arguments are `$(LDFLAGS) -L.`.
   An alternative could be to have `LDFLAGS+=.L` and then use `$(LDFLAGS)` afterwards.
2. There are these conditional `LIBS+=-fsanitize=*` lines.
   Those got me a little confused; these should be compiler flags and having them in `CFLAGS` should suffice, shouldn't it?
3. How do you feel about changing `CPPFLAGS=-DHAVE_KALLOC` to `CPPFLAGS+=-DHAVE_KALLOC`?
   This way `CPPFLAGS` from the environment can be reused but the user still has the possibility to override via `make CPPFLAGS=...`.
4. (Less important) How do you feel about changing `CFLAGS=...` to `CFLAGS?=...`?
   With that, custom `CFLAGS` don't have to be explicitly passed on as `make` arguments.
